### PR TITLE
Improve favicon logic

### DIFF
--- a/scripts/fetch-favicons.js
+++ b/scripts/fetch-favicons.js
@@ -90,7 +90,22 @@ class FaviconFetcher {
 				}
 			}
 		} catch {
-			// Fall through to direct fetch
+			// Fall through to other fallbacks
+		}
+
+		// Secondary: DuckDuckGo's icons service (another reliable, lightweight source)
+		try {
+			const ddgUrl = `https://icons.duckduckgo.com/ip3/${rootDomain}.ico`;
+			const response = await this.fetchWithTimeout(ddgUrl);
+			if (response.ok) {
+				const data = await response.arrayBuffer();
+				// Accept if non-trivial (avoids empty/placeholder responses)
+				if (data.byteLength > 100) {
+					return data;
+				}
+			}
+		} catch {
+			// Fall through to direct site fetch
 		}
 
 		// Fallback: Try direct favicon.ico from site

--- a/scripts/fetch-favicons.js
+++ b/scripts/fetch-favicons.js
@@ -4,13 +4,15 @@ import { fileURLToPath } from 'url';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const CONCURRENCY_LIMIT = 5;
-const TIMEOUT_MS = 10000;
+const TIMEOUT_MS = 8000;
+const FORCE_REFRESH = process.argv.includes('--force');
 
 class FaviconFetcher {
-	constructor() {
+	constructor(existingManifest = {}) {
 		this.successCount = 0;
+		this.skipCount = 0;
 		this.failCount = 0;
-		this.manifest = {};
+		this.manifest = { ...existingManifest };
 	}
 
 	/**
@@ -52,57 +54,59 @@ class FaviconFetcher {
 	}
 
 	/**
-	 * Try fetching favicon from multiple sources with fallback strategy
+	 * Check if favicon already exists in cache
+	 */
+	async faviconExists(website) {
+		if (FORCE_REFRESH) return false;
+		if (!this.manifest[website]) return false;
+
+		const faviconPath = path.join(__dirname, '../public', this.manifest[website]);
+		try {
+			await fs.access(faviconPath);
+			return true;
+		} catch {
+			return false;
+		}
+	}
+
+	/**
+	 * Try fetching favicon with a simple, fast strategy:
+	 * 1. Google's favicon service (fast, reliable)
+	 * 2. Direct favicon.ico from site (fallback)
 	 */
 	async tryFetchFavicon(website) {
 		const rootDomain = this.getRootDomain(website);
-		const protocols = ['https', 'http'];
-		const paths = [website, rootDomain];
-		const filenames = ['favicon.ico', 'favicon.png'];
 
-		// Try combinations of protocol, path, and filename
-		for (const protocol of protocols) {
-			for (const targetPath of paths) {
-				// Skip duplicate if website has no subdirectory
-				if (
-					targetPath === rootDomain &&
-					website === rootDomain &&
-					protocol === 'http'
-				) {
-					continue;
-				}
-
-				for (const filename of filenames) {
-					const url = `${protocol}://${targetPath}/${filename}`;
-					try {
-						const response = await this.fetchWithTimeout(url);
-						if (response.ok) {
-							const contentType =
-								response.headers.get('content-type');
-							// Verify it's actually an image
-							if (
-								contentType &&
-								contentType.startsWith('image/')
-							) {
-								return await response.arrayBuffer();
-							}
-						}
-					} catch (error) {
-						// Silent fail, try next option
-					}
-				}
-			}
-		}
-
-		// Final fallback: Google's favicon service
+		// Primary: Google's favicon service (most reliable and fast)
 		try {
 			const googleUrl = `https://www.google.com/s2/favicons?domain=${rootDomain}&sz=32`;
 			const response = await this.fetchWithTimeout(googleUrl);
 			if (response.ok) {
-				return await response.arrayBuffer();
+				const data = await response.arrayBuffer();
+				// Google returns a default globe icon for unknown domains (small size)
+				// Accept if it's reasonably sized (> 100 bytes)
+				if (data.byteLength > 100) {
+					return data;
+				}
 			}
-		} catch (error) {
-			// All options exhausted
+		} catch {
+			// Fall through to direct fetch
+		}
+
+		// Fallback: Try direct favicon.ico from site
+		for (const targetPath of [website, rootDomain]) {
+			try {
+				const url = `https://${targetPath}/favicon.ico`;
+				const response = await this.fetchWithTimeout(url);
+				if (response.ok) {
+					const contentType = response.headers.get('content-type');
+					if (contentType?.startsWith('image/')) {
+						return await response.arrayBuffer();
+					}
+				}
+			} catch {
+				// Silent fail, try next
+			}
 		}
 
 		return null;
@@ -112,7 +116,14 @@ class FaviconFetcher {
 	 * Fetch favicon for a single member
 	 */
 	async fetchFaviconForMember(member, index, total) {
-		const { website, name } = member;
+		const { website } = member;
+
+		// Skip if already cached
+		if (await this.faviconExists(website)) {
+			this.skipCount++;
+			console.log(`⏭️  ${website} (cached) (${index + 1}/${total})`);
+			return;
+		}
 
 		try {
 			const faviconData = await this.tryFetchFavicon(website);
@@ -120,7 +131,7 @@ class FaviconFetcher {
 			if (faviconData) {
 				// Save favicon to public/favicons/
 				const sanitized = this.sanitizeFilename(website);
-				const filename = `${sanitized}.png`;
+				const filename = `${sanitized}.ico`;
 				const faviconPath = path.join(
 					__dirname,
 					'../public/favicons',
@@ -134,12 +145,15 @@ class FaviconFetcher {
 				this.successCount++;
 				console.log(`✅ ${website} (${index + 1}/${total})`);
 			} else {
+				// Mark as needing fallback in manifest
+				this.manifest[website] = null;
 				this.failCount++;
 				console.log(
-					`⚠️  ${website}: All sources failed, using fallback (${index + 1}/${total})`,
+					`⚠️  ${website}: using fallback (${index + 1}/${total})`,
 				);
 			}
 		} catch (error) {
+			this.manifest[website] = null;
 			this.failCount++;
 			console.log(
 				`⚠️  ${website}: ${error.message} (${index + 1}/${total})`,
@@ -185,18 +199,32 @@ class FaviconFetcher {
 async function main() {
 	const startTime = Date.now();
 
+	if (FORCE_REFRESH) {
+		console.log('🔄 Force refresh enabled, re-fetching all favicons...\n');
+	}
+
 	try {
 		// Read members.json
 		const membersPath = path.join(__dirname, '../src/members.json');
 		const membersData = await fs.readFile(membersPath, 'utf-8');
 		const members = JSON.parse(membersData);
 
+		// Load existing manifest for caching
+		const manifestPath = path.join(__dirname, '../src/favicon-manifest.json');
+		let existingManifest = {};
+		try {
+			const manifestData = await fs.readFile(manifestPath, 'utf-8');
+			existingManifest = JSON.parse(manifestData);
+		} catch {
+			// No existing manifest, start fresh
+		}
+
 		// Create public/favicons directory if it doesn't exist
 		const faviconsDir = path.join(__dirname, '../public/favicons');
 		await fs.mkdir(faviconsDir, { recursive: true });
 
 		// Fetch all favicons
-		const fetcher = new FaviconFetcher();
+		const fetcher = new FaviconFetcher(existingManifest);
 		await fetcher.fetchAllFavicons(members);
 
 		// Write manifest
@@ -205,14 +233,8 @@ async function main() {
 		// Summary
 		const duration = ((Date.now() - startTime) / 1000).toFixed(1);
 		console.log(
-			`📊 Summary: Successfully fetched ${fetcher.successCount}/${members.length} favicons in ${duration}s`,
+			`\n📊 Summary: ${fetcher.successCount} fetched, ${fetcher.skipCount} cached, ${fetcher.failCount} fallback (${duration}s)`,
 		);
-
-		if (fetcher.failCount > 0) {
-			console.log(
-				`   ${fetcher.failCount} favicon(s) will use the amrita.town fallback logo`,
-			);
-		}
 	} catch (error) {
 		console.error('❌ Fatal error:', error.message);
 		process.exit(1);

--- a/src/components/MemberList.astro
+++ b/src/components/MemberList.astro
@@ -3,8 +3,12 @@ import members from '@/members.json';
 import faviconManifest from '@/favicon-manifest.json';
 import ExternalLink from '@/components/graphics/ExternalLink.svg';
 
-const getFaviconSrc = (website: string) => {
-	return faviconManifest[website] || '/favicon.png';
+const FALLBACK_FAVICON = '/favicon.png';
+
+const getFaviconSrc = (website: string): string => {
+	const entry = faviconManifest[website];
+	// null = explicitly failed, undefined = not in manifest, string = valid path
+	return typeof entry === 'string' ? entry : FALLBACK_FAVICON;
 };
 ---
 


### PR DESCRIPTION
# Summary
+ Swapped the favicon pipeline to rely on Google’s service as the primary source
+ Added DuckDuckGo as a secondary fallback service to cover sites that still miss icons

P.S use --force to refresh cache